### PR TITLE
docs(spec): remove Dependencies section

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -109,17 +109,6 @@ The primary new feature: configure installed container apps through a web interf
 - Must work alongside cockpit-apt without conflicts
 - Must read store configurations in the same format as cockpit-apt previously used
 
-### Dependencies
-
-- **cockpit-apt-utils**: Shared Python utility library providing:
-  - Error handling classes
-  - JSON formatting utilities
-  - Input validation functions
-  - Store configuration loading
-  - Store filter matching logic
-  - Debtag parsing
-  - Repository metadata parsing
-
 ## Key Constraints
 
 ### Architectural Constraints


### PR DESCRIPTION
## Summary

- Remove Dependencies section from SPEC.md
- Dependencies are implementation details that belong in ARCHITECTURE.md
- Utils will be vendored from cockpit-apt at build time (documented in upcoming ARCHITECTURE.md)

## Test plan

- [x] SPEC.md still contains all specification-level requirements
- [ ] Review that no essential requirements were removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)