### PR TITLE
fix(build): remove pybuild from debian/rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,9 +1,7 @@
 #!/usr/bin/make -f
 
-export PYBUILD_NAME=cockpit-container-apps
-
 %:
-	dh $@ --with python3 --buildsystem=pybuild
+	dh $@
 
 override_dh_auto_build:
 	# Build Python backend
@@ -25,6 +23,5 @@ override_dh_auto_test:
 	@echo "Skipping tests during package build"
 
 override_dh_auto_clean:
-	dh_auto_clean
 	rm -rf backend/dist backend/build backend/*.egg-info
 	rm -rf frontend/dist frontend/node_modules


### PR DESCRIPTION
## Problem

CI/CD builds on main were failing with:
```
E: pybuild pybuild:129: cannot detect build system
dh_auto_clean: error: pybuild --clean returned exit code 11
```

## Solution

Removed `--buildsystem=pybuild` from debian/rules since:
1. The backend is in a subdirectory which pybuild can't detect
2. We're doing custom builds anyway (hatchling for backend, npm for frontend)
3. We don't need pybuild's automatic detection

## Changes

- Removed `export PYBUILD_NAME` and `--with python3 --buildsystem=pybuild`
- Removed `dh_auto_clean` call from override (it uses pybuild)
- Manual cleanup is sufficient for our build structure

## Testing

Will verify the CI build passes after this PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)