### PR TITLE
fix(build): install Python package files to /usr instead of /usr/local

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: cockpit-container-apps
 Section: admin
 Priority: optional
 Maintainer: Matti Airas <matti.airas@hatlabs.fi>
-Build-Depends: debhelper-compat (= 13), nodejs, npm, python3-all, python3-apt, python3-hatchling, python3-yaml, dh-python
+Build-Depends: debhelper-compat (= 13), nodejs, npm, python3-all, python3-apt, python3-hatchling, python3-yaml, dh-python, pybuild-plugin-pyproject
 Standards-Version: 4.6.2
 Homepage: https://github.com/hatlabs/cockpit-container-apps
 

--- a/debian/rules
+++ b/debian/rules
@@ -1,27 +1,21 @@
 #!/usr/bin/make -f
 
+export PYBUILD_NAME=cockpit-container-apps
+export PYBUILD_DISABLE=test
+export PYBUILD_SYSTEM=pyproject
+
 %:
-	dh $@
+	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_auto_build:
-	# Build Python backend
-	cd backend && python3 -m hatchling build
+	# Build Python backend using pybuild in backend/ subdirectory
+	dh_auto_build -- --dir backend
 	# Build frontend
 	cd frontend && npm ci && npm run build
 
 override_dh_auto_install:
-	# Install Python package to temporary location first
-	mkdir -p $(CURDIR)/debian/tmp
-	cd backend && python3 -m pip install --no-deps --prefix=/usr --root=$(CURDIR)/debian/tmp dist/*.whl
-	# Move files from /usr/local to /usr (pip ignores --prefix for some paths)
-	mkdir -p $(CURDIR)/debian/cockpit-container-apps/usr/bin
-	mkdir -p $(CURDIR)/debian/cockpit-container-apps/usr/lib/python3/dist-packages
-	if [ -d "$(CURDIR)/debian/tmp/usr/local/bin" ]; then \
-		cp -r $(CURDIR)/debian/tmp/usr/local/bin/* $(CURDIR)/debian/cockpit-container-apps/usr/bin/; \
-	fi
-	if [ -d "$(CURDIR)/debian/tmp/usr/local/lib" ]; then \
-		cp -r $(CURDIR)/debian/tmp/usr/local/lib/python*/dist-packages/* $(CURDIR)/debian/cockpit-container-apps/usr/lib/python3/dist-packages/; \
-	fi
+	# Install Python package using pybuild
+	dh_auto_install -- --dir backend
 	# Install frontend to Cockpit directory
 	mkdir -p $(CURDIR)/debian/cockpit-container-apps/usr/share/cockpit/container-apps
 	cp -r frontend/dist/* $(CURDIR)/debian/cockpit-container-apps/usr/share/cockpit/container-apps/
@@ -33,9 +27,6 @@ override_dh_auto_test:
 	@echo "Skipping tests during package build"
 
 override_dh_auto_clean:
+	dh_auto_clean -- --dir backend || true
 	rm -rf backend/dist backend/build backend/*.egg-info
 	rm -rf frontend/dist frontend/node_modules
-
-override_dh_missing:
-	# Don't fail on missing files - we manually copy what we need
-	dh_missing --list-missing

--- a/docker/Dockerfile.debtools
+++ b/docker/Dockerfile.debtools
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
     lintian \
     nodejs \
     npm \
+    pybuild-plugin-pyproject \
     python3 \
     python3-all \
     python3-apt \


### PR DESCRIPTION
## Problem

CI/CD builds were failing due to pip installing files to `/usr/local/` which violates Debian policy.

## Solution

**Use standard Debian packaging tools** instead of pip:

### Changes
- **debian/rules**: Use `pybuild` with `--dir backend` to handle subdirectory structure
- **debian/control**: Add `pybuild-plugin-pyproject` to Build-Depends for PEP 517 support
- **docker/Dockerfile.debtools**: Include `pybuild-plugin-pyproject` in build image

### How it works
```makefile
export PYBUILD_SYSTEM=pyproject  # Use pyproject.toml (hatchling)

override_dh_auto_build:
	dh_auto_build -- --dir backend  # Build from backend/ subdirectory
	
override_dh_auto_install:
	dh_auto_install -- --dir backend  # Install using pybuild
```

### Benefits
✅ Uses standard Debian tools (dh-python, pybuild)  
✅ Handles PEP 517 backends (hatchling) properly  
✅ Automatically installs to `/usr/bin` and `/usr/lib/python3/dist-packages`  
✅ `dh_python3` fixes script shebangs automatically  
✅ No manual file copying required  

## Testing

✅ Built package locally with standard tools:
```
📦 Generated packages:
-rw-r--r--  1 mairas  staff   1.2M Nov 24 20:01 cockpit-container-apps_0.1.0-1_all.deb
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)