### PR TITLE
fix: implement category filtering and improve UI consistency

### DIFF
--- a/backend/cockpit_container_apps/cli.py
+++ b/backend/cockpit_container_apps/cli.py
@@ -49,9 +49,9 @@ Commands:
   list-categories [--store ID]          List all categories (auto-discovered from tags)
   list-packages-by-category CATEGORY [--store ID]
                                         List all packages in a category
-  filter-packages [OPTIONS]             Filter packages by store, repo, tab, search, limit
-                                        OPTIONS: [--store ID] [--repo ID] [--tab TAB]
-                                                 [--search QUERY] [--limit N]
+  filter-packages [OPTIONS]             Filter packages by store, repo, category, tab, search, limit
+                                        OPTIONS: [--store ID] [--repo ID] [--category ID]
+                                                 [--tab TAB] [--search QUERY] [--limit N]
   install PACKAGE                       Install a package (with progress)
   remove PACKAGE                        Remove a package (with progress)
 
@@ -149,6 +149,7 @@ def main() -> NoReturn:
             # Parse optional parameters
             store_id = None
             repository_id = None
+            category_id = None
             tab = None
             search_query = None
             limit = 1000
@@ -164,6 +165,11 @@ def main() -> NoReturn:
                     if i + 1 >= len(sys.argv):
                         raise APTBridgeError("--repo requires a value", code="INVALID_ARGUMENTS")
                     repository_id = sys.argv[i + 1]
+                    i += 2
+                elif sys.argv[i] == "--category":
+                    if i + 1 >= len(sys.argv):
+                        raise APTBridgeError("--category requires a value", code="INVALID_ARGUMENTS")
+                    category_id = sys.argv[i + 1]
                     i += 2
                 elif sys.argv[i] == "--tab":
                     if i + 1 >= len(sys.argv):
@@ -198,6 +204,7 @@ def main() -> NoReturn:
             result = filter_packages.execute(
                 store_id=store_id,
                 repository_id=repository_id,
+                category_id=category_id,
                 tab=tab,
                 search_query=search_query,
                 limit=limit,

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -159,6 +159,9 @@ export async function filterPackages(params: FilterParams = {}): Promise<FilterP
     if (params.repository_id) {
         args.push('--repo', params.repository_id);
     }
+    if (params.category_id) {
+        args.push('--category', params.category_id);
+    }
     if (params.tab) {
         args.push('--tab', params.tab);
     }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -110,6 +110,7 @@ export interface Package {
 export interface FilterParams {
     store_id?: string;
     repository_id?: string;
+    category_id?: string;
     tab?: 'installed' | 'upgradable';
     search_query?: string;
     limit?: number;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,0 +1,36 @@
+/* Override PatternFly's default behavior that removes rounded frame on mobile */
+/* Keep the rounded frame at all viewport sizes, matching Cockpit's built-in modules */
+
+/* These variables are applied on the parent .pf-v6-c-page element by PatternFly */
+.pf-v6-c-page {
+    /* Keep margins on mobile (creates spacing from edges) */
+    --pf-v6-c-page__main-container--xs--MarginInlineStart: var(--pf-v6-c-page--inset) !important;
+    --pf-v6-c-page__main-container--xs--MarginInlineEnd: var(--pf-v6-c-page--inset) !important;
+
+    /* Keep all borders on mobile (not just top) */
+    --pf-v6-c-page__main-container--xs--BorderBlockEndWidth: var(
+        --pf-t--global--border--width--main--default
+    ) !important;
+    --pf-v6-c-page__main-container--xs--BorderInlineStartWidth: var(
+        --pf-t--global--border--width--main--default
+    ) !important;
+    --pf-v6-c-page__main-container--xs--BorderInlineEndWidth: var(
+        --pf-t--global--border--width--main--default
+    ) !important;
+}
+
+/* This variable is applied on the child .pf-v6-c-page__main-container element */
+.pf-v6-c-page__main-container {
+    /* Keep border radius on mobile */
+    --pf-v6-c-page__main-container--xs--BorderRadius: var(
+        --pf-t--global--border--radius--medium
+    ) !important;
+
+    /* Keep bottom margin on mobile (don't let frame touch bottom edge) */
+    --pf-v6-c-page__main-container--xs--MaxHeight: calc(
+        100% - var(--pf-t--global--spacer--lg)
+    ) !important;
+
+    /* Fill viewport height at all viewport sizes (not just content height) */
+    align-self: stretch !important;
+}

--- a/frontend/src/components/AppListView.tsx
+++ b/frontend/src/components/AppListView.tsx
@@ -53,7 +53,11 @@ export const AppListView: React.FC<AppListViewProps> = ({
     if (isLoading) {
         return (
             <PageSection>
-                <Spinner aria-label="Loading apps" />
+                <EmptyState titleText="Loading apps..." headingLevel="h3">
+                    <EmptyStateBody>
+                        <Spinner size="xl" aria-label="Loading apps" />
+                    </EmptyStateBody>
+                </EmptyState>
             </PageSection>
         );
     }
@@ -85,11 +89,7 @@ export const AppListView: React.FC<AppListViewProps> = ({
     if (packages.length === 0) {
         return (
             <PageSection>
-                <EmptyState
-                    titleText="No apps available"
-                    icon={CubeIcon}
-                    headingLevel="h2"
-                >
+                <EmptyState titleText="No apps available" icon={CubeIcon} headingLevel="h2">
                     <EmptyStateBody>
                         There are no apps matching your current filters.
                     </EmptyStateBody>

--- a/frontend/src/components/CategoriesView.tsx
+++ b/frontend/src/components/CategoriesView.tsx
@@ -45,11 +45,18 @@ export const CategoriesView: React.FC<CategoriesViewProps> = ({
     onRetry,
     title,
 }) => {
+    // Debug: log loading state
+    console.log('CategoriesView render:', { isLoading, categoriesCount: categories.length, error });
+
     // Loading state
     if (isLoading) {
         return (
             <PageSection>
-                <Spinner aria-label="Loading categories" />
+                <EmptyState titleText="Loading categories..." headingLevel="h3">
+                    <EmptyStateBody>
+                        <Spinner size="xl" aria-label="Loading categories" />
+                    </EmptyStateBody>
+                </EmptyState>
             </PageSection>
         );
     }
@@ -81,11 +88,7 @@ export const CategoriesView: React.FC<CategoriesViewProps> = ({
     if (categories.length === 0) {
         return (
             <PageSection>
-                <EmptyState
-                    titleText="No categories available"
-                    icon={CubesIcon}
-                    headingLevel="h2"
-                >
+                <EmptyState titleText="No categories available" icon={CubesIcon} headingLevel="h2">
                     <EmptyStateBody>
                         There are no categories available in this store.
                     </EmptyStateBody>

--- a/frontend/src/dark-theme.ts
+++ b/frontend/src/dark-theme.ts
@@ -1,0 +1,74 @@
+/**
+ * Dark theme support for cockpit-container-apps
+ *
+ * Listens to Cockpit's theme preferences and system dark mode.
+ * Applies PatternFly v6 dark theme class to document root.
+ */
+
+// Extend Window interface for Cockpit debugging
+declare global {
+    interface Window {
+        debugging?: string | string[];
+    }
+}
+
+function debug(...args: unknown[]) {
+    if (window.debugging === 'all' || window.debugging?.includes('style')) {
+        console.debug(`cockpit-container-apps dark-theme:`, ...args);
+    }
+}
+
+function setDarkMode(style?: string) {
+    const themeStyle = style || localStorage.getItem('shell:style') || 'auto';
+    let darkMode = false;
+
+    // Check if dark mode should be enabled
+    if (themeStyle === 'dark') {
+        darkMode = true;
+    } else if (
+        themeStyle === 'auto' &&
+        window.matchMedia?.('(prefers-color-scheme: dark)').matches
+    ) {
+        darkMode = true;
+    }
+
+    debug(`Setting theme to ${darkMode ? 'dark' : 'light'} (style=${themeStyle})`);
+
+    // Apply PatternFly v6 dark theme class
+    if (darkMode) {
+        document.documentElement.classList.add('pf-v6-theme-dark');
+    } else {
+        document.documentElement.classList.remove('pf-v6-theme-dark');
+    }
+}
+
+// Listen for localStorage changes from other tabs/windows
+window.addEventListener('storage', (event) => {
+    if (event.key === 'shell:style') {
+        debug(`Storage changed: ${event.oldValue} → ${event.newValue}`);
+        setDarkMode();
+    }
+});
+
+// Listen for Cockpit shell theme changes in same window
+window.addEventListener('cockpit-style', (event) => {
+    if (event instanceof CustomEvent) {
+        const style = event.detail.style;
+        debug(`Cockpit style event: ${style}`);
+        setDarkMode(style);
+    }
+});
+
+// Listen for OS theme preference changes
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    debug(
+        `OS theme changed: ${window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'}`
+    );
+    setDarkMode();
+});
+
+// Set initial theme
+setDarkMode();
+
+// Export to make this a module
+export {};

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -5,6 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Container Apps</title>
         <link rel="stylesheet" href="index.css" />
+        <script src="../base1/cockpit.js"></script>
     </head>
     <body>
         <div id="app"></div>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,8 +5,16 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
 
+// Import both PatternFly CSS files
+// patternfly-base.css contains design tokens (--pf-t--global--* variables)
+// patternfly.css contains component styles that reference those tokens
+// Both are required for proper styling!
+import '@patternfly/patternfly/patternfly-base.css';
 import '@patternfly/patternfly/patternfly.css';
-import '@patternfly/patternfly/patternfly-addons.css';
+// Import dark theme support (must be after PatternFly CSS)
+import './dark-theme';
+// Import our custom CSS overrides LAST so they take precedence over PatternFly defaults
+import './app.css';
 
 const container = document.getElementById('app');
 if (container) {


### PR DESCRIPTION
## Summary
This PR fixes the major category filtering issue where clicking on a category would show all apps instead of just apps in that category. It also includes comprehensive UI improvements for better consistency and user experience.

## Problem
When users clicked on a category, they saw "No apps available" briefly, then ALL store apps were shown instead of just the apps in the selected category. The root cause was that the `category_id` parameter was missing from the data pipeline.

## Changes

### 1. Category Filtering (Primary Fix)
**Backend** (`backend/cockpit_container_apps/commands/filter_packages.py`):
- Added `category_id` parameter to filter_packages command  
- Implemented filtering by debtag facets (`category::` tags)
- Updated filter cascade order: store → repository → **category** → tab → search

**Backend CLI** (`backend/cockpit_container_apps/cli.py`):
- Added `--category` parameter parsing
- Updated usage documentation

**Frontend API** (`frontend/src/api/index.ts`, `frontend/src/api/types.ts`):
- Added `category_id` to FilterParams type
- Pass `--category` argument to backend CLI

**Frontend Context** (`frontend/src/context/AppContext.tsx`):
- Pass `activeCategory` when loading packages
- Auto-select first store if none selected (fixes Installed tab showing all Debian packages)

**Frontend App** (`frontend/src/App.tsx`):
- Removed incorrect client-side filtering by section (categories ≠ sections)

### 2. UI Improvements
**Loading States**:
- Replaced bare spinners with `EmptyState` components for proper centering
- Added "Loading..." messages for better UX
- Fixed `CategoriesView` and `AppListView` spinners

**Layout & Styling**:
- Added PatternFly base CSS imports for design tokens
- Implemented dark theme detection (`frontend/src/dark-theme.ts`)
- Added custom CSS overrides (`frontend/src/app.css`) for:
  - Rounded frame at all viewport sizes
  - Proper margins and spacing
  - Viewport filling behavior
- Removed sidebar to avoid conflict with Cockpit's navigation
- Changed to tab-based navigation

**Missing Dependencies**:
- Added missing `cockpit.js` script tag in `index.html`

## Testing
Tested on halos.local:
1. ✅ Categories load with centered spinner
2. ✅ Clicking a category shows only apps in that category
3. ✅ Installed tab shows only installed apps from the store
4. ✅ Dark theme switches automatically with Cockpit
5. ✅ Layout matches cockpit-apt styling

## Before/After

**Before**:
- Category click → "No apps available" → Shows ALL apps
- Bare spinners not centered
- Installed tab showed all Debian packages
- No dark theme support
- Layout inconsistent with cockpit-apt

**After**:
- Category click → Shows ONLY apps in that category
- Properly centered loading states with messages
- Installed tab shows only container apps from store
- Full dark theme support
- Consistent layout and styling

## Related Issues
Fixes the "No apps available" issue when navigating to categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>