### PR TITLE
fix: parse JSON string in set-config command

### DIFF
--- a/backend/cockpit_container_apps/cli.py
+++ b/backend/cockpit_container_apps/cli.py
@@ -23,6 +23,7 @@ Example Usage:
     $ cockpit-container-apps list-stores
 """
 
+import json
 import sys
 from typing import Any, NoReturn
 
@@ -268,8 +269,23 @@ def main() -> NoReturn:
                     code="INVALID_ARGUMENTS",
                 )
             package_name = sys.argv[2]
-            config_json = sys.argv[3]
-            result = set_config.execute(package_name, config_json)
+            config_json_str = sys.argv[3]
+
+            # Parse JSON string to dictionary
+            try:
+                config_dict = json.loads(config_json_str)
+                if not isinstance(config_dict, dict):
+                    raise APTBridgeError(
+                        "Config must be a JSON object",
+                        code="INVALID_ARGUMENTS",
+                    )
+            except json.JSONDecodeError as e:
+                raise APTBridgeError(
+                    f"Invalid JSON: {e}",
+                    code="INVALID_JSON",
+                ) from None
+
+            result = set_config.execute(package_name, config_dict)
 
         elif command in ("--help", "-h", "help"):
             print_usage()


### PR DESCRIPTION
## Summary

Three related fixes for configuration saving functionality discovered during testing.

## Fix 1: Parse JSON String in CLI Handler

**Problem**: The set-config handler was passing JSON string directly to execute():
```python
config_json = sys.argv[3]
result = set_config.execute(package_name, config_json)  # ❌ Passes string
```

Caused error: **'str' object has no attribute 'keys'**

**Solution**: Parse JSON to dictionary with proper error handling

## Fix 2: Filter Non-Schema Fields in Frontend

**Problem**: ConfigForm was sending ALL loaded config values, including fields from env.defaults that aren't in the schema (e.g., CONTAINER_DATA_ROOT).

Caused error: **Unknown configuration field(s): CONTAINER_DATA_ROOT**

**Solution**: Filter formValues to only include schema-defined fields before saving

## Impact

These fixes complete the configuration save functionality. With both fixes:
- ✅ Backend correctly parses JSON config data
- ✅ Frontend only sends schema-defined fields
- ✅ Configuration can be saved successfully

## Testing

```bash
# Should now work correctly
# 1. Load config form for installed app
# 2. Edit field value
# 3. Click Save
# 4. Configuration saves without errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)