### PR TITLE
fix: filter out non-schema fields when saving config

### DIFF
--- a/frontend/src/components/ConfigForm.tsx
+++ b/frontend/src/components/ConfigForm.tsx
@@ -163,7 +163,23 @@ export function ConfigForm({
             return;
         }
 
-        onSave(formValues);
+        // Only send values for fields defined in the schema
+        // Filter out any extra fields that might be in formValues (e.g., from env.defaults)
+        const schemaFieldIds = new Set<string>();
+        schema.groups.forEach((group) => {
+            group.fields.forEach((field) => {
+                schemaFieldIds.add(field.id);
+            });
+        });
+
+        const filteredConfig: ConfigValues = {};
+        for (const [key, value] of Object.entries(formValues)) {
+            if (schemaFieldIds.has(key)) {
+                filteredConfig[key] = value;
+            }
+        }
+
+        onSave(filteredConfig);
     }
 
     /**


### PR DESCRIPTION
## Summary

Fix ConfigForm to only send schema-defined fields when saving configuration.

## Problem

get-config returns merged config including fields from env.defaults that may not be in the schema:
```json
{
  "CONTAINER_DATA_ROOT": "/var/lib/container-apps/avnav-container/data",
  "AVNAV_HTTP_PORT": "8082"
}
```

But config schema only defines:
```json
{
  "fields": [{"id": "AVNAV_HTTP_PORT", ...}]
}
```

ConfigForm was sending ALL loaded values including CONTAINER_DATA_ROOT, causing backend validation error:

> Unknown configuration field(s): CONTAINER_DATA_ROOT

## Solution

Filter formValues to only include fields defined in schema before saving:

```typescript
// Build set of schema field IDs
const schemaFieldIds = new Set<string>();
schema.groups.forEach(group => {
  group.fields.forEach(field => schemaFieldIds.add(field.id));
});

// Filter to only schema fields
const filteredConfig = Object.entries(formValues)
  .filter(([key]) => schemaFieldIds.has(key));
```

## Testing

1. Install avnav-container
2. Open configuration form
3. Change AVNAV_HTTP_PORT
4. Click Save
5. Should save successfully (no "Unknown configuration field" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)