### PR TITLE
fix(ci): add concurrency group to prevent race condition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,11 @@ name: Main Branch CI/CD
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.repository }}-main-release
+  cancel-in-progress: false
 
 jobs:
   build-release:


### PR DESCRIPTION
## Summary
- Add concurrency group to the main CI workflow
- Prevents race conditions when multiple PRs are merged in quick succession
- Without this fix, concurrent runs could calculate the same revision number, causing one to fail

## Test plan
- [ ] Verify CI runs successfully
- [ ] Merge multiple PRs in quick succession to test concurrency handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)