### PR TITLE
ci: enable frontend test suite in pr-checks

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -27,8 +27,7 @@ runs:
       run: .github/scripts/build-frontend.sh
       shell: bash
 
-    # Frontend tests will be enabled when frontend implementation is complete
-    # - name: Run frontend tests
-    #   working-directory: frontend
-    #   run: npm test
-    #   shell: bash
+    - name: Run frontend tests
+      working-directory: frontend
+      run: npm test
+      shell: bash

--- a/frontend/src/__tests__/App.navigation.test.tsx
+++ b/frontend/src/__tests__/App.navigation.test.tsx
@@ -170,6 +170,12 @@ vi.mock('../api', () => ({
     updatePackageLists: vi.fn().mockResolvedValue(undefined),
     formatErrorMessage: vi.fn((e: unknown) => String(e)),
     ContainerAppsError: class extends Error {},
+    // ServiceLog calls this when its card is expanded; default to a no-op handle.
+    streamServiceJournal: vi.fn(() => ({ close: vi.fn() })),
+    // AppDetails loads per-package config when the app is installed.
+    getConfigSchema: vi.fn().mockResolvedValue({ version: '1.0', groups: [] }),
+    getConfig: vi.fn().mockResolvedValue({}),
+    setConfig: vi.fn().mockResolvedValue({ success: true }),
 }));
 
 describe('App Navigation Integration', () => {

--- a/frontend/src/components/__tests__/ConfigFields.test.tsx
+++ b/frontend/src/components/__tests__/ConfigFields.test.tsx
@@ -117,20 +117,20 @@ describe('BooleanField', () => {
 
     it('renders switch in off state when value is false', () => {
         render(<BooleanField field={baseField} value="false" onChange={vi.fn()} />);
-        const toggle = screen.getByRole('checkbox') as HTMLInputElement;
+        const toggle = screen.getByRole('switch') as HTMLInputElement;
         expect(toggle.checked).toBe(false);
     });
 
     it('renders switch in on state when value is true', () => {
         render(<BooleanField field={baseField} value="true" onChange={vi.fn()} />);
-        const toggle = screen.getByRole('checkbox') as HTMLInputElement;
+        const toggle = screen.getByRole('switch') as HTMLInputElement;
         expect(toggle.checked).toBe(true);
     });
 
     it('calls onChange when toggled', async () => {
         const handleChange = vi.fn();
         render(<BooleanField field={baseField} value="false" onChange={handleChange} />);
-        const toggle = screen.getByRole('checkbox');
+        const toggle = screen.getByRole('switch');
         await userEvent.click(toggle);
         expect(handleChange).toHaveBeenCalledWith('ENABLE_SSL', 'true');
     });
@@ -160,8 +160,10 @@ describe('EnumField', () => {
         const select = screen.getByRole('button'); // PatternFly Select uses button
         await userEvent.click(select);
 
+        // PatternFly v6 Select echoes the current selection in the menu toggle,
+        // so the currently-selected label ("Info") appears twice.
         expect(screen.getByText('Debug')).toBeInTheDocument();
-        expect(screen.getByText('Info')).toBeInTheDocument();
+        expect(screen.getAllByText('Info').length).toBeGreaterThanOrEqual(1);
         expect(screen.getByText('Warning')).toBeInTheDocument();
         expect(screen.getByText('Error')).toBeInTheDocument();
     });


### PR DESCRIPTION
## Why

The frontend suite (245 tests across 17 files) has been ready to run for a while, but the step in `.github/actions/run-tests/action.yml` was commented out. PR checks have therefore only ever exercised the backend — regressions in the React layer (e.g. PatternFly v6 ARIA changes, mock drift) only surface when a contributor happens to run `npm test` locally. Two pre-existing failure clusters had to be cleared before enabling the step:

| Cluster | Failing tests | Root cause |
|---|---|---|
| `frontend/src/__tests__/App.navigation.test.tsx` | 4 | `vi.mock('../api', …)` was missing `streamServiceJournal`, `getConfig`, `getConfigSchema`, `setConfig`. The mock predates the `ServiceLog` and `ConfigForm` components; vitest's strict-mock check fires at import time. |
| `frontend/src/components/__tests__/ConfigFields.test.tsx` | 4 | PatternFly v6 changed `Switch`'s ARIA role from `checkbox` to `switch`, and `Select` now echoes the current selection into the menu toggle so `screen.getByText('Info')` matches two nodes. The tests still targeted v5 behavior. |

## What changed

### 1. `App.navigation.test.tsx` — extend the api mock factory

Added the four missing functions to the `vi.mock('../api', …)` factory so the test bundle resolves cleanly:

- `streamServiceJournal` returns a stub `{ close: vi.fn() }` handle — `ServiceLog` calls this when its card is expanded.
- `getConfigSchema` resolves to an empty schema, `getConfig` to `{}`, `setConfig` to `{ success: true }` — `AppDetails` loads per-package config when the app is installed.

These defaults are no-ops; tests that need richer behavior can override per-case as usual.

### 2. `ConfigFields.test.tsx` — track PatternFly v6 ARIA changes

- All three `BooleanField` assertions now use `screen.getByRole('switch')` instead of `'checkbox'`.
- `EnumField > renders select with all options` uses `getAllByText('Info').length` for the currently-selected option (which now appears both in the toggle and the menu). The other three options still use `getByText`.

### 3. `.github/actions/run-tests/action.yml` — uncomment the step

Replaced the commented-out block with the active `Run frontend tests` step and removed the "will be enabled when frontend implementation is complete" comment.

## Verification

Local run: `cd frontend && npm test` reports **17 test files, 245 tests passed**, no failures. Lint and typecheck have the same three pre-existing issues as `main`; nothing new from this PR.

Before this PR the suite was `237 passing / 8 failing` (same 8 covered above). After: `245 passing / 0 failing`. Net delta: +8 previously-broken tests now green.

## Out of scope

- `src/api/index.ts:556`, `src/utils/appStatus.ts:27`, `ConfigForm.tsx:153`, `ServiceLog.tsx:55` — pre-existing typecheck/lint issues on `main`, not introduced here, tracked separately.

## Closes / refs

Closes #81