### PR TITLE
test(navigation): waitFor the URL-filter aria-pressed assertion

### DIFF
--- a/frontend/src/__tests__/App.navigation.test.tsx
+++ b/frontend/src/__tests__/App.navigation.test.tsx
@@ -400,11 +400,18 @@ describe('App Navigation Integration', () => {
             render(<App />);
 
             // Should apply the filter
-            const installedButton = await screen.findByText('Installed');
+            await screen.findByText('Installed');
 
-            // Filter should be selected
-            const button = installedButton.closest('button');
-            expect(button).toHaveAttribute('aria-pressed', 'true');
+            // Filter should be selected. Wrapped in waitFor so the assertion
+            // tolerates the extra render cycle introduced by useAdminPermission's
+            // null → resolved transition — without it the check can race the
+            // permission resolution under CI load and observe aria-pressed=false.
+            await waitFor(() => {
+                expect(screen.getByText('Installed').closest('button')).toHaveAttribute(
+                    'aria-pressed',
+                    'true',
+                );
+            });
         });
     });
 


### PR DESCRIPTION
## Why

`halos-manage-certs` re-signs the TLS leaf once on every boot.

The cert service is ordered `Before=halos-core-containers.service`, so it runs before NetworkManager has settled. The domain resolver chain (`hostname -d` → `nmcli`) returns nothing, the `${fqdn}` line in `hostnames.conf` soft-drops, and the leaf is signed with `.local`-only SANs — with the sentinel stored for that set. ~15 min later the renewal timer fires, DHCP has provided a domain, `${fqdn}` now expands to `<host>.hal`, the hostname hash changes, the sentinel mismatches, and the leaf is re-signed. Verified on halosdev.local: boot signed `[halosdev.local]`, the timer logged "Hostname list or CA changed, re-signing" and expanded to `[halosdev.hal, halosdev.local]`.

The `.hal` SAN is wanted (real unicast DNS, more robust than mDNS `.local`). The bug is the *instability of when it's included*, not the SAN.

## How

Make `_halos_resolve_domain` sticky: persist the last-known-good domain and reuse it when the live chain resolves nothing. After the first provisioning, every subsequent boot signs with the full SAN set immediately → stable hostname hash → no re-sign. A genuinely different live domain overwrites the stored value, so real domain changes still produce one legitimate re-sign.

Fixing this in the resolver (not in cert code) stabilizes the hostname set for every consumer — cert SANs, Authelia per-hostname cookies, and OIDC `redirect_uris`.

- State at `/var/lib/halos/resolved-domain`; override via `HALOS_HOSTNAMES_DOMAIN_STATE`, set-empty disables (test isolation). All state I/O is best-effort and never fails resolution (consumers run under `set -e`). Persisted writes are gated on `_halos_domain_safe`, so a garbage/injected value can't be replayed into cert SANs.
- Default path is fixed (not derived from `CONTAINER_DATA_ROOT`) so all loader consumers agree without each setting the env.

**Trade-off:** a device that *permanently* moves to a network with no DHCP domain keeps its old FQDN as a stale-but-harmless cert SAN until a domain resolves again. Deliberate — distinguishing transient from permanent absence isn't worth the complexity. `After=network-online.target` was rejected (it would push the whole stack behind `NetworkManager-wait-online` on every offline boot).

## Tests

5 new tests in `test-lib-hostnames.sh`: reuse-on-transient-empty, genuine-change-overwrites, disabled-keeps-stateless, garbage-not-persisted, and a consumer-level check that the hostname hash is identical across a resolving boot and a subsequent empty-resolution boot (the outcome that gates re-signing). Full suite green.

## Verify on a device

Reboot twice and confirm `halos-manage-certs` logs no "Hostname list or CA changed" re-sign on the second boot.

Closes #164. Extracted from #160 (closed — self-signed revert dropped, no benefit once #161/#162 fixed the HSTS symptom).
