### PR TITLE
refactor(ui): align AdminGatedButton to canonical ButtonProps shape

### DIFF
--- a/frontend/src/components/AdminGatedButton.tsx
+++ b/frontend/src/components/AdminGatedButton.tsx
@@ -1,0 +1,39 @@
+import { Button, Tooltip } from '@patternfly/react-core';
+import type { ButtonProps } from '@patternfly/react-core';
+
+export const ADMIN_REQUIRED_TOOLTIP =
+    'Administrative access is required. Click "Limited access" in the top bar to authenticate.';
+
+export interface AdminGatedButtonProps extends ButtonProps {
+    isAdminRequired: boolean;
+}
+
+/**
+ * Button wrapper that uses PatternFly's `isAriaDisabled` (which suppresses
+ * onClick via preventDefault) when admin is required but not granted, and
+ * wraps the disabled button in a tooltip explaining why.
+ *
+ * All standard `Button` props are forwarded. When any disable reason is set
+ * (`isAdminRequired`, `isAriaDisabled`, or `isDisabled`), the underlying
+ * Button is rendered with `isAriaDisabled` so click suppression composes with
+ * the admin tooltip.
+ */
+export function AdminGatedButton({
+    isAdminRequired,
+    isAriaDisabled,
+    isDisabled,
+    children,
+    ...rest
+}: AdminGatedButtonProps) {
+    const button = (
+        <Button {...rest} isAriaDisabled={isAdminRequired || isAriaDisabled || isDisabled}>
+            {children}
+        </Button>
+    );
+
+    if (isAdminRequired) {
+        return <Tooltip content={ADMIN_REQUIRED_TOOLTIP}>{button}</Tooltip>;
+    }
+
+    return button;
+}

--- a/frontend/src/components/AppDetails.tsx
+++ b/frontend/src/components/AppDetails.tsx
@@ -28,7 +28,6 @@ import {
     ProgressSize,
     Spinner,
     Title,
-    Tooltip,
 } from '@patternfly/react-core';
 import { CubeIcon } from '@patternfly/react-icons';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -36,12 +35,10 @@ import { formatErrorMessage, getConfig, getConfigSchema, setConfig } from '../ap
 import type { ConfigSchema, ConfigValues, Package } from '../api/types';
 import { useAdminPermission } from '../hooks/useAdminPermission';
 import { getStatusConfig } from '../utils/appStatus';
+import { AdminGatedButton } from './AdminGatedButton';
 import { BreadcrumbNav } from './BreadcrumbNav';
 import { ConfigForm } from './ConfigForm';
 import { ServiceLog } from './ServiceLog';
-
-const ADMIN_REQUIRED_TOOLTIP =
-    'Administrative access is required. Click "Limited access" in the top bar to authenticate.';
 
 export interface AppDetailsProps {
     /** Package to display */
@@ -297,8 +294,9 @@ export const AppDetails: React.FC<AppDetailsProps> = ({
                                             onClick={handleInstallClick}
                                             isDisabled={isActionInProgress}
                                             isAdminRequired={isAdminRequired}
-                                            label="Install"
-                                        />
+                                        >
+                                            Install
+                                        </AdminGatedButton>
                                     </FlexItem>
                                 ) : (
                                     <>
@@ -309,8 +307,9 @@ export const AppDetails: React.FC<AppDetailsProps> = ({
                                                     onClick={handleUpdateClick}
                                                     isDisabled={isActionInProgress}
                                                     isAdminRequired={isAdminRequired}
-                                                    label="Update"
-                                                />
+                                                >
+                                                    Update
+                                                </AdminGatedButton>
                                             </FlexItem>
                                         )}
                                         <FlexItem>
@@ -319,8 +318,9 @@ export const AppDetails: React.FC<AppDetailsProps> = ({
                                                 onClick={handleUninstallClick}
                                                 isDisabled={isActionInProgress}
                                                 isAdminRequired={isAdminRequired}
-                                                label="Uninstall"
-                                            />
+                                            >
+                                                Uninstall
+                                            </AdminGatedButton>
                                         </FlexItem>
                                     </>
                                 )}
@@ -482,8 +482,9 @@ export const AppDetails: React.FC<AppDetailsProps> = ({
                             variant="primary"
                             onClick={handleConfirmInstall}
                             isAdminRequired={isAdminRequired}
-                            label="Install anyway"
-                        />
+                        >
+                            Install anyway
+                        </AdminGatedButton>
                         <Button variant="link" onClick={() => setShowInstallConfirm(false)}>
                             Cancel
                         </Button>
@@ -492,32 +493,4 @@ export const AppDetails: React.FC<AppDetailsProps> = ({
             )}
         </PageSection>
     );
-};
-
-interface AdminGatedButtonProps {
-    variant: 'primary' | 'danger';
-    label: string;
-    onClick: () => void;
-    isAdminRequired: boolean;
-    isDisabled?: boolean;
-}
-
-const AdminGatedButton: React.FC<AdminGatedButtonProps> = ({
-    variant,
-    label,
-    onClick,
-    isAdminRequired,
-    isDisabled,
-}) => {
-    const button = (
-        <Button variant={variant} onClick={onClick} isAriaDisabled={isAdminRequired || isDisabled}>
-            {label}
-        </Button>
-    );
-
-    if (isAdminRequired) {
-        return <Tooltip content={ADMIN_REQUIRED_TOOLTIP}>{button}</Tooltip>;
-    }
-
-    return button;
 };


### PR DESCRIPTION
## Why

This module's `AdminGatedButton` was a hand-enumerated subset (`variant`, `label`, `onClick`, `isAdminRequired`, `isDisabled`) inlined in `AppDetails.tsx`. That restrictive surface blocked legitimate PatternFly props and diverged from the canonical shape already adopted by the other gated modules (cockpit-apt, cockpit-authelia-users) and documented in `docs/solutions/best-practices/2026-05-28-cockpit-module-admin-gating-and-error-surfacing.md`.

Part of halos-org/halos#127 (scope item 1, this module). With cockpit-apt and cockpit-authelia-users already canonical and cockpit-networkmanager-halos#13 now merged, this brings the pilot in line — the last divergent copy.

## How

- Extract the inline component into `frontend/src/components/AdminGatedButton.tsx` as `interface AdminGatedButtonProps extends ButtonProps`, spreading `...rest` onto `Button` and gating via `isAriaDisabled`.
- Convert the 4 call sites (Install, Update, Uninstall, "Install anyway") from the `label` prop to children.
- Remove the now-unused inline interface, duplicate tooltip const, and `Tooltip` import from `AppDetails.tsx`.

The pilot's richer tooltip text is kept deliberately (the existing test asserts it, and it's more actionable than the terse canonical string); only the prop shape is aligned.

## Verification

- `npm run typecheck` — 0 errors
- `npm run test` — 282 passed (19 files), including the existing AppDetails tooltip/aria-disabled tests
- VERSION not bumped (per workspace version-bump policy)

Scope item 3 of #127 (extracting into a shared package) is intentionally left out.